### PR TITLE
fix: derived events pass initial pipeline stage

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -7357,11 +7357,12 @@ int BPF_KPROBE(cgroup_bpf_run_filter_skb)
 
     // copy orig task ctx (from the netctx) to event ctx and build the rest
     __builtin_memcpy(&eventctx->task, &netctx->taskctx, sizeof(task_context_t));
-    eventctx->ts = p.event->context.ts;                     // copy timestamp from current ctx
-    eventctx->argnum = 1;                                   // 1 argument (add more if needed)
-    eventctx->eventid = NET_PACKET_IP;                      // will be changed in skb program
-    eventctx->stack_id = 0;                                 // no stack trace
-    eventctx->processor_id = p.event->context.processor_id; // copy from current ctx
+    eventctx->ts = p.event->context.ts;                         // copy timestamp from current ctx
+    eventctx->argnum = 1;                                       // 1 argument (add more if needed)
+    eventctx->eventid = NET_PACKET_IP;                          // will be changed in skb program
+    eventctx->stack_id = 0;                                     // no stack trace
+    eventctx->processor_id = p.event->context.processor_id;     // copy from current ctx
+    eventctx->matched_scopes = p.event->context.matched_scopes; // copy from current ctx
 
     // inform userland about protocol family (for correct L3 header parsing)...
     struct sock_common *common = (void *) sk;


### PR DESCRIPTION
Check: https://github.com/aquasecurity/tracee/pull/2238/files#r1073081999

fix: derived events pass initial pipeline stage

- allows base events for derived ones to pass the initial pipeline stage, they will eventually be filtered in/out in the deriveEvent stage.

- add matched_scope to the network events so they can be correctly filtered.