### PR TITLE
ebpf: check event submit by scope with map

### DIFF
--- a/pkg/ebpf/c/tracee.bpf.c
+++ b/pkg/ebpf/c/tracee.bpf.c
@@ -883,8 +883,6 @@ typedef struct config_entry {
     u64 uid_min;
     u64 pid_max;
     u64 pid_min;
-    // use 8*128 bits to describe up to 1024 events
-    u8 events_to_submit[128];
 } config_entry_t;
 
 typedef struct event_data {
@@ -1069,6 +1067,7 @@ BPF_HASH(uts_ns_filter, string_filter_t, eq_t, 256);               // filter eve
 BPF_HASH(comm_filter, string_filter_t, eq_t, 256);                 // filter events by command name
 BPF_HASH(cgroup_id_filter, u32, eq_t, 256);                        // filter events by cgroup id
 BPF_HASH(binary_filter, binary_t, eq_t, 256);                      // filter events by binary path and mount namespace
+BPF_HASH(events_map, u32, u64, MAX_EVENT_ID);                      // map to persist event configuration data (currently submit scopes)
 BPF_HASH(bin_args_map, u64, bin_args_t, 256);                      // persist args for send_bin funtion
 BPF_HASH(sys_32_to_64_map, u32, u32, 1024);                        // map 32bit to 64bit syscalls
 BPF_HASH(params_types_map, u32, u64, 1024);                        // encoded parameters types for event
@@ -2270,13 +2269,25 @@ static __always_inline u64 should_trace(program_data_t *p)
     return p->task_info->matched_scopes;
 }
 
-static __always_inline int should_submit(u32 event_id, config_entry_t *config)
+static __always_inline u64 should_submit(u32 event_id, program_data_t *p)
 {
-    volatile unsigned int index = event_id / 8;
-    unsigned int offset = event_id % 8;
-    u8 bitmap = config->events_to_submit[index % 128];
+    // use a map only with no submit cache from config.
+    // since this function is only ever called after a should_trace
+    // and in the context of a submit program/tail_call, any preemptive
+    // cache calculation before checking the map will 99% of times be
+    // redundant.
+    // a probe/tail call attach almost always implies at least one
+    // scope requires the event to be submitted.
+    u64 *event_scopes = bpf_map_lookup_elem(&events_map, &event_id);
+    // if scopes not set, don't submit
+    if (event_scopes == NULL) {
+        return 0;
+    }
 
-    return bitmap & (1 << offset);
+    // align with previously matched scopes
+    p->event->context.matched_scopes &= *event_scopes;
+
+    return p->event->context.matched_scopes;
 }
 
 // INTERNAL: BUFFERS -------------------------------------------------------------------------------
@@ -3076,7 +3087,7 @@ static __always_inline uint get_syscall_fd_num_from_arg(uint syscall_id, args_t 
         if (!init_program_data(&p, ctx))                                                           \
             return 0;                                                                              \
                                                                                                    \
-        if (!should_submit(id, p.config))                                                          \
+        if (!should_submit(id, &p))                                                                \
             return 0;                                                                              \
                                                                                                    \
         save_args_to_submit_buf(p->event, types, &args);                                           \
@@ -3539,6 +3550,8 @@ int sys_exit_submit(struct bpf_raw_tracepoint_args *ctx)
         // We can't use saved args after execve syscall, as pointers are
         // invalid To avoid showing execve event both on entry and exit, we
         // only output failed execs
+        if (!should_submit(id, &p))
+            return 0;
         u64 types = 0;
         u64 *saved_types = bpf_map_lookup_elem(&params_types_map, &id);
         if (!saved_types) {
@@ -3571,6 +3584,9 @@ int trace_sys_enter(struct bpf_raw_tracepoint_args *ctx)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(RAW_SYS_ENTER, &p))
+        return 0;
+
     // always submit since this won't be attached otherwise
     int id = ctx->args[1];
     struct task_struct *task = (struct task_struct *) bpf_get_current_task();
@@ -3596,6 +3612,9 @@ int trace_sys_exit(struct bpf_raw_tracepoint_args *ctx)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(RAW_SYS_EXIT, &p))
         return 0;
 
     // always submit since this won't be attached otherwise
@@ -3628,7 +3647,7 @@ int syscall__execve(void *ctx)
         return -1;
     syscall_data_t *sys = &p.task_info->syscall_data;
 
-    if (!should_submit(SYSCALL_EXECVE, p.config))
+    if (!should_submit(SYSCALL_EXECVE, &p))
         return 0;
 
     save_str_to_buf(p.event, (void *) sys->args.args[0] /*filename*/, 0);
@@ -3651,7 +3670,7 @@ int syscall__execveat(void *ctx)
         return -1;
     syscall_data_t *sys = &p.task_info->syscall_data;
 
-    if (!should_submit(SYSCALL_EXECVEAT, p.config))
+    if (!should_submit(SYSCALL_EXECVEAT, &p))
         return 0;
 
     save_to_submit_buf(p.event, (void *) &sys->args.args[0] /*dirfd*/, sizeof(int), 0);
@@ -3667,7 +3686,7 @@ int syscall__execveat(void *ctx)
 
 static __always_inline int send_socket_dup(program_data_t *p, u64 oldfd, u64 newfd)
 {
-    if (!should_submit(SOCKET_DUP, p->config))
+    if (!should_submit(SOCKET_DUP, p))
         return 0;
 
     if (!check_fd_type(oldfd, S_IFSOCK)) {
@@ -3820,7 +3839,7 @@ int tracepoint__sched__sched_process_fork(struct bpf_raw_tracepoint_args *ctx)
     // follow every pid that passed the should_trace() checks (used by the follow filter)
     c_proc_info->follow_in_scopes = p.task_info->matched_scopes;
 
-    if (should_submit(SCHED_PROCESS_FORK, p.config) || p.config->options & OPT_PROCESS_INFO) {
+    if (should_submit(SCHED_PROCESS_FORK, &p) || p.config->options & OPT_PROCESS_INFO) {
         int parent_ns_pid = get_task_ns_pid(parent);
         int parent_ns_tgid = get_task_ns_tgid(parent);
         int child_ns_pid = get_task_ns_pid(child);
@@ -3896,7 +3915,7 @@ int tracepoint__sched__sched_process_exec(struct bpf_raw_tracepoint_args *ctx)
     // Follow this task for matched scopes
     proc_info->follow_in_scopes = p.task_info->matched_scopes;
 
-    if (!should_submit(SCHED_PROCESS_EXEC, p.config) &&
+    if (!should_submit(SCHED_PROCESS_EXEC, &p) &&
         (p.config->options & OPT_PROCESS_INFO) != OPT_PROCESS_INFO)
         return 0;
 
@@ -4008,7 +4027,7 @@ int tracepoint__sched__sched_process_exit(struct bpf_raw_tracepoint_args *ctx)
 
     long exit_code = get_task_exit_code(p.event->task);
 
-    if (should_submit(SCHED_PROCESS_EXIT, p.config) || p.config->options & OPT_PROCESS_INFO) {
+    if (should_submit(SCHED_PROCESS_EXIT, &p) || p.config->options & OPT_PROCESS_INFO) {
         save_to_submit_buf(p.event, (void *) &exit_code, sizeof(long), 0);
         save_to_submit_buf(p.event, (void *) &group_dead, sizeof(bool), 1);
 
@@ -4118,7 +4137,7 @@ int tracepoint__sched__sched_switch(struct bpf_raw_tracepoint_args *ctx)
     if (!should_trace(&p))
         return 0;
 
-    if (!should_submit(SCHED_SWITCH, p.config))
+    if (!should_submit(SCHED_SWITCH, &p))
         return 0;
 
     struct task_struct *prev = (struct task_struct *) ctx->args[1];
@@ -4146,6 +4165,9 @@ int BPF_KPROBE(trace_filldir64)
     if (!should_trace((&p)))
         return 0;
 
+    if (!should_submit(HIDDEN_INODES, &p))
+        return 0;
+
     char *process_name = (char *) PT_REGS_PARM2(ctx);
     unsigned long process_inode_number = (unsigned long) PT_REGS_PARM5(ctx);
     if (process_inode_number == 0) {
@@ -4163,6 +4185,9 @@ int BPF_KPROBE(trace_call_usermodehelper)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(CALL_USERMODE_HELPER, &p))
         return 0;
 
     void *path = (void *) PT_REGS_PARM1(ctx);
@@ -4186,6 +4211,9 @@ int BPF_KPROBE(trace_do_exit)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(DO_EXIT, &p))
         return 0;
 
     long code = PT_REGS_PARM1(ctx);
@@ -4472,7 +4500,7 @@ static __always_inline void *get_trace_probe_from_trace_event_call(struct trace_
 static __always_inline int
 send_bpf_attach(program_data_t *p, struct file *bpf_prog_file, struct file *perf_event_file)
 {
-    if (!should_submit(BPF_ATTACH, p->config)) {
+    if (!should_submit(BPF_ATTACH, p)) {
         return 0;
     }
 
@@ -4736,6 +4764,9 @@ int BPF_KPROBE(trace_security_bprm_check)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_BPRM_CHECK, &p))
+        return 0;
+
     struct linux_binprm *bprm = (struct linux_binprm *) PT_REGS_PARM1(ctx);
     struct file *file = get_file_ptr_from_bprm(bprm);
     dev_t s_dev = get_dev_from_file(file);
@@ -4757,6 +4788,9 @@ int BPF_KPROBE(trace_security_file_open)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_FILE_OPEN, &p))
         return 0;
 
     struct file *file = (struct file *) PT_REGS_PARM1(ctx);
@@ -4804,6 +4838,9 @@ int BPF_KPROBE(trace_security_sb_mount)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_SB_MOUNT, &p))
+        return 0;
+
     const char *dev_name = (const char *) PT_REGS_PARM1(ctx);
     struct path *path = (struct path *) PT_REGS_PARM2(ctx);
     const char *type = (const char *) PT_REGS_PARM3(ctx);
@@ -4829,6 +4866,9 @@ int BPF_KPROBE(trace_security_inode_unlink)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_INODE_UNLINK, &p))
+        return 0;
+
     // struct inode *dir = (struct inode *)PT_REGS_PARM1(ctx);
     struct dentry *dentry = (struct dentry *) PT_REGS_PARM2(ctx);
     void *dentry_path = get_dentry_path_str(dentry);
@@ -4852,6 +4892,9 @@ int BPF_KPROBE(trace_commit_creds)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(COMMIT_CREDS, &p))
         return 0;
 
     struct cred *new = (struct cred *) PT_REGS_PARM1(ctx);
@@ -4943,6 +4986,9 @@ int BPF_KPROBE(trace_switch_task_namespaces)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SWITCH_TASK_NS, &p))
+        return 0;
+
     struct task_struct *task = (struct task_struct *) PT_REGS_PARM1(ctx);
     struct nsproxy *new = (struct nsproxy *) PT_REGS_PARM2(ctx);
 
@@ -4993,6 +5039,9 @@ int BPF_KPROBE(trace_cap_capable)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(CAP_CAPABLE, &p))
+        return 0;
+
     int cap = PT_REGS_PARM3(ctx);
     int cap_opt = PT_REGS_PARM4(ctx);
 
@@ -5014,6 +5063,9 @@ int BPF_KPROBE(trace_security_socket_create)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_SOCKET_CREATE, &p))
         return 0;
 
     int family = (int) PT_REGS_PARM1(ctx);
@@ -5039,6 +5091,9 @@ int BPF_KPROBE(trace_security_inode_symlink)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_INODE_SYMLINK, &p))
+        return 0;
+
     // struct inode *dir = (struct inode *)PT_REGS_PARM1(ctx);
     struct dentry *dentry = (struct dentry *) PT_REGS_PARM2(ctx);
     const char *old_name = (const char *) PT_REGS_PARM3(ctx);
@@ -5061,6 +5116,9 @@ int BPF_KPROBE(trace_proc_create)
     if (!should_trace((&p)))
         return 0;
 
+    if (!should_submit(PROC_CREATE, &p))
+        return 0;
+
     char *name = (char *) PT_REGS_PARM1(ctx);
     unsigned long proc_ops_addr = (unsigned long) PT_REGS_PARM4(ctx);
 
@@ -5078,6 +5136,9 @@ int BPF_KPROBE(trace_debugfs_create_file)
         return 0;
 
     if (!should_trace((&p)))
+        return 0;
+
+    if (!should_submit(DEBUGFS_CREATE_FILE, &p))
         return 0;
 
     char *name = (char *) PT_REGS_PARM1(ctx);
@@ -5104,6 +5165,9 @@ int BPF_KPROBE(trace_debugfs_create_dir)
     if (!should_trace((&p)))
         return 0;
 
+    if (!should_submit(DEBUGFS_CREATE_DIR, &p))
+        return 0;
+
     char *name = (char *) PT_REGS_PARM1(ctx);
     struct dentry *dentry = (struct dentry *) PT_REGS_PARM2(ctx);
     void *dentry_path = get_dentry_path_str(dentry);
@@ -5122,6 +5186,9 @@ int BPF_KPROBE(trace_security_socket_listen)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_SOCKET_LISTEN, &p))
         return 0;
 
     struct socket *sock = (struct socket *) PT_REGS_PARM1(ctx);
@@ -5147,6 +5214,9 @@ int BPF_KPROBE(trace_security_socket_connect)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_SOCKET_CONNECT, &p))
         return 0;
 
     struct sockaddr *address = (struct sockaddr *) PT_REGS_PARM2(ctx);
@@ -5199,12 +5269,15 @@ int BPF_KPROBE(trace_security_socket_accept)
     struct socket *new_sock = (struct socket *) PT_REGS_PARM2(ctx);
 
     // save sockets for "socket_accept event"
-    if (should_submit(SOCKET_ACCEPT, p.config)) {
+    if (should_submit(SOCKET_ACCEPT, &p)) {
         args_t args = {};
         args.args[0] = (unsigned long) sock;
         args.args[1] = (unsigned long) new_sock;
         save_args(&args, SOCKET_ACCEPT);
     }
+
+    if (!should_submit(SECURITY_SOCKET_ACCEPT, &p))
+        return 0;
 
     // Load the arguments given to the accept syscall (which eventually invokes this function)
     syscall_data_t *sys = &p.task_info->syscall_data;
@@ -5225,6 +5298,9 @@ int BPF_KPROBE(trace_security_socket_bind)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_SOCKET_BIND, &p))
         return 0;
 
     struct socket *sock = (struct socket *) PT_REGS_PARM1(ctx);
@@ -5292,6 +5368,9 @@ int BPF_KPROBE(trace_security_socket_setsockopt)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_SOCKET_SETSOCKOPT, &p))
         return 0;
 
     struct socket *sock = (struct socket *) PT_REGS_PARM1(ctx);
@@ -5471,6 +5550,7 @@ submit_magic_write(program_data_t *p, file_info_t *file_info, io_data_t io_data,
     p->event->context.argnum = 0;
 
     u8 header[FILE_MAGIC_HDR_SIZE];
+    __builtin_memset(&header, 0, sizeof(header));
 
     save_str_to_buf(p->event, file_info->pathname_p, 0);
 
@@ -5481,6 +5561,7 @@ submit_magic_write(program_data_t *p, file_info_t *file_info, io_data_t io_data,
             bpf_probe_read(header, FILE_MAGIC_HDR_SIZE, io_data.ptr);
     } else {
         struct iovec io_vec;
+        __builtin_memset(&io_vec, 0, sizeof(io_vec));
         bpf_probe_read(&io_vec, sizeof(struct iovec), io_data.ptr);
         if (header_bytes < FILE_MAGIC_HDR_SIZE)
             bpf_probe_read(header, header_bytes & FILE_MAGIC_MASK, io_vec.iov_base);
@@ -5496,11 +5577,11 @@ submit_magic_write(program_data_t *p, file_info_t *file_info, io_data_t io_data,
     return events_perf_submit(p, MAGIC_WRITE, bytes_written);
 }
 
-static __always_inline bool should_submit_io_event(u32 event_id, config_entry_t *config)
+static __always_inline bool should_submit_io_event(u32 event_id, program_data_t *p)
 {
     return ((event_id == VFS_READ || event_id == VFS_READV || event_id == VFS_WRITE ||
              event_id == VFS_WRITEV || event_id == __KERNEL_WRITE) &&
-            should_submit(event_id, config));
+            should_submit(event_id, p));
 }
 
 /** do_file_io_operation - generic file IO (read and write) event creator.
@@ -5520,14 +5601,16 @@ do_file_io_operation(struct pt_regs *ctx, u32 event_id, u32 tail_call_id, bool i
         return 0;
     }
 
-    int zero = 0;
-    config_entry_t *config = bpf_map_lookup_elem(&config_map, &zero);
-    if (config == NULL) {
+    program_data_t p = {};
+    if (!init_program_data(&p, ctx)) {
         del_args(event_id);
         return 0;
     }
 
-    if (!should_submit_io_event(event_id, config) && !should_submit(MAGIC_WRITE, config)) {
+    bool should_submit_magic_write = should_submit(MAGIC_WRITE, &p);
+    bool should_submit_io = should_submit_io_event(event_id, &p);
+
+    if (!should_submit_io && !should_submit_magic_write) {
         bpf_tail_call(ctx, &prog_array, tail_call_id);
         del_args(event_id);
         return 0;
@@ -5557,13 +5640,7 @@ do_file_io_operation(struct pt_regs *ctx, u32 event_id, u32 tail_call_id, bool i
     if (start_pos != 0)
         start_pos -= io_bytes_amount;
 
-    program_data_t p = {};
-    if (!init_program_data(&p, ctx)) {
-        del_args(event_id);
-        return 0;
-    }
-
-    if (should_submit_io_event(event_id, p.config)) {
+    if (should_submit_io) {
         save_str_to_buf(p.event, file_info.pathname_p, 0);
         save_to_submit_buf(p.event, &file_info.device, sizeof(dev_t), 1);
         save_to_submit_buf(p.event, &file_info.inode, sizeof(unsigned long), 2);
@@ -5575,7 +5652,7 @@ do_file_io_operation(struct pt_regs *ctx, u32 event_id, u32 tail_call_id, bool i
     }
 
     // magic_write event checks if the header of some file is changed
-    if (!is_read && should_submit(MAGIC_WRITE, config) && !char_dev && (start_pos == 0)) {
+    if (!is_read && should_submit_magic_write && !char_dev && (start_pos == 0)) {
         submit_magic_write(&p, &file_info, io_data, io_bytes_amount);
     }
 
@@ -5785,7 +5862,8 @@ int BPF_KPROBE(trace_mmap_alert)
 
     int prot = sys->args.args[2];
 
-    if ((prot & (VM_WRITE | VM_EXEC)) == (VM_WRITE | VM_EXEC)) {
+    if ((prot & (VM_WRITE | VM_EXEC)) == (VM_WRITE | VM_EXEC) &&
+        should_submit(MEM_PROT_ALERT, &p)) {
         u32 alert = ALERT_MMAP_W_X;
         int fd = sys->args.args[5];
         void *addr = (void *) sys->args.args[0];
@@ -5807,6 +5885,9 @@ int BPF_KPROBE(trace_ret_do_mmap)
 {
     program_data_t p = {};
     if (!init_program_data(&p, ctx))
+        return 0;
+
+    if (!should_submit(DO_MMAP, &p))
         return 0;
 
     args_t saved_args;
@@ -5862,6 +5943,9 @@ int BPF_KPROBE(trace_security_mmap_file)
     if (!should_trace(&p))
         return 0;
 
+    if (should_submit(SECURITY_MMAP_FILE, &p))
+        return 0;
+
     struct file *file = (struct file *) PT_REGS_PARM1(ctx);
     if (file == 0)
         return 0;
@@ -5879,14 +5963,14 @@ int BPF_KPROBE(trace_security_mmap_file)
     save_to_submit_buf(p.event, &ctime, sizeof(u64), 4);
 
     int id = -1;
-    if (should_submit(SHARED_OBJECT_LOADED, p.config)) {
+    if (should_submit(SHARED_OBJECT_LOADED, &p)) {
         id = get_task_syscall_id(p.event->task);
         if ((prot & VM_EXEC) == VM_EXEC && id == SYSCALL_MMAP) {
             events_perf_submit(&p, SHARED_OBJECT_LOADED, 0);
         }
     }
 
-    if (should_submit(SECURITY_MMAP_FILE, p.config)) {
+    if (should_submit(SECURITY_MMAP_FILE, &p)) {
         save_to_submit_buf(p.event, &prot, sizeof(unsigned long), 5);
         save_to_submit_buf(p.event, &mmap_flags, sizeof(unsigned long), 6);
         if (id == -1) { // if id wasn't checked yet, do so now.
@@ -5917,8 +6001,8 @@ int BPF_KPROBE(trace_security_file_mprotect)
         (sys->id != SYSCALL_MPROTECT && sys->id != SYSCALL_PKEY_MPROTECT))
         return 0;
 
-    int should_submit_mprotect = should_submit(SECURITY_FILE_MPROTECT, p.config);
-    int should_submit_mem_prot_alert = should_submit(MEM_PROT_ALERT, p.config);
+    int should_submit_mprotect = should_submit(SECURITY_FILE_MPROTECT, &p);
+    int should_submit_mem_prot_alert = should_submit(MEM_PROT_ALERT, &p);
 
     if (!should_submit_mprotect && !should_submit_mem_prot_alert) {
         return 0;
@@ -5950,7 +6034,7 @@ int BPF_KPROBE(trace_security_file_mprotect)
         events_perf_submit(&p, SECURITY_FILE_MPROTECT, 0);
     }
 
-    if (should_submit(MEM_PROT_ALERT, p.config)) {
+    if (should_submit_mem_prot_alert) {
         void *addr = (void *) sys->args.args[0];
         size_t len = sys->args.args[1];
 
@@ -6089,7 +6173,7 @@ int BPF_KPROBE(trace_security_bpf)
 
     int cmd = (int) PT_REGS_PARM1(ctx);
 
-    if (should_submit(SECURITY_BPF, p.config)) {
+    if (should_submit(SECURITY_BPF, &p)) {
         // 1st argument == cmd (int)
         save_to_submit_buf(p.event, (void *) &cmd, sizeof(int), 0);
 
@@ -6160,6 +6244,9 @@ int BPF_KPROBE(trace_security_bpf_map)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(SECURITY_BPF_MAP, &p))
         return 0;
 
     struct bpf_map *map = (struct bpf_map *) PT_REGS_PARM1(ctx);
@@ -6278,6 +6365,9 @@ int BPF_KPROBE(trace_security_kernel_read_file)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_KERNEL_READ_FILE, &p))
+        return 0;
+
     struct file *file = (struct file *) PT_REGS_PARM1(ctx);
     dev_t s_dev = get_dev_from_file(file);
     unsigned long inode_nr = get_inode_nr_from_file(file);
@@ -6315,7 +6405,7 @@ int BPF_KPROBE(trace_security_kernel_post_read_file)
     enum kernel_read_file_id type_id = (enum kernel_read_file_id) PT_REGS_PARM4(ctx);
 
     // Send event if chosen
-    if (should_submit(SECURITY_POST_READ_FILE, p.config)) {
+    if (should_submit(SECURITY_POST_READ_FILE, &p)) {
         void *file_path = get_path_str(&file->f_path);
         save_str_to_buf(p.event, file_path, 0);
         save_to_submit_buf(p.event, &size, sizeof(loff_t), 1);
@@ -6355,6 +6445,9 @@ int BPF_KPROBE(trace_security_inode_mknod)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_INODE_MKNOD, &p))
+        return 0;
+
     struct dentry *dentry = (struct dentry *) PT_REGS_PARM2(ctx);
     unsigned short mode = (unsigned short) PT_REGS_PARM3(ctx);
     unsigned int dev = (unsigned int) PT_REGS_PARM4(ctx);
@@ -6375,6 +6468,9 @@ int BPF_KPROBE(trace_device_add)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(DEVICE_ADD, &p))
         return 0;
 
     struct device *dev = (struct device *) PT_REGS_PARM1(ctx);
@@ -6407,6 +6503,9 @@ int BPF_KPROBE(trace_ret__register_chrdev)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+    
+    if (!should_submit(REGISTER_CHRDEV, &p))
         return 0;
 
     unsigned int major_number = (unsigned int) saved_args.args[0];
@@ -6504,7 +6603,7 @@ int BPF_KPROBE(trace_ret_do_splice)
     if (!should_trace(&p))
         return 0;
 
-    if (!should_submit(DIRTY_PIPE_SPLICE, p.config))
+    if (!should_submit(DIRTY_PIPE_SPLICE, &p))
         return 0;
 
     // Catch only successful splice
@@ -6626,6 +6725,8 @@ int BPF_KPROBE(trace_ret_do_init_module)
     program_data_t p = {};
     if (!init_program_data(&p, ctx))
         return 0;
+    if (!should_submit(DO_INIT_MODULE, &p))
+        return 0;
 
     kmod_data_t *orig_module_data =
         bpf_map_lookup_elem(&module_init_map, &p.event->context.task.host_tid);
@@ -6687,7 +6788,7 @@ int BPF_KPROBE(trace_load_elf_phdrs)
     proc_info->interpreter.inode = get_inode_nr_from_file(loaded_elf);
     proc_info->interpreter.ctime = get_ctime_nanosec_from_file(loaded_elf);
 
-    if (should_submit(LOAD_ELF_PHDRS, p.config)) {
+    if (should_submit(LOAD_ELF_PHDRS, &p)) {
         save_str_to_buf(p.event, (void *) elf_pathname, 0);
         save_to_submit_buf(p.event, &proc_info->interpreter.device, sizeof(dev_t), 1);
         save_to_submit_buf(p.event, &proc_info->interpreter.inode, sizeof(unsigned long), 2);
@@ -6718,6 +6819,9 @@ int BPF_KPROBE(trace_security_file_permission)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+        
+    if (!should_submit(HOOKED_PROC_FOPS, &p))
         return 0;
 
     struct file_operations *fops = (struct file_operations *) READ_KERN(f_inode->i_fop);
@@ -6764,6 +6868,9 @@ int tracepoint__task__task_rename(struct bpf_raw_tracepoint_args *ctx)
     if (!should_trace((&p)))
         return 0;
 
+    if (!should_submit(TASK_RENAME, &p))
+        return 0;
+
     struct task_struct *tsk = (struct task_struct *) ctx->args[0];
     char old_name[TASK_COMM_LEN];
     bpf_probe_read_str(&old_name, TASK_COMM_LEN, tsk->comm);
@@ -6787,20 +6894,17 @@ int BPF_KPROBE(trace_security_inode_rename)
     if (!should_trace(&p))
         return 0;
 
+    if (!should_submit(SECURITY_INODE_RENAME, &p))
+        return 0;
+
     struct dentry *old_dentry = (struct dentry *) PT_REGS_PARM2(ctx);
     struct dentry *new_dentry = (struct dentry *) PT_REGS_PARM4(ctx);
 
-    if (should_submit(SECURITY_INODE_RENAME, p.config)) {
-        void *old_dentry_path = get_dentry_path_str(old_dentry);
-        save_str_to_buf(p.event, old_dentry_path, 0);
-
-        void *new_dentry_path = get_dentry_path_str(new_dentry);
-        save_str_to_buf(p.event, new_dentry_path, 1);
-
-        events_perf_submit(&p, SECURITY_INODE_RENAME, 0);
-    }
-
-    return 0;
+    void *old_dentry_path = get_dentry_path_str(old_dentry);
+    void *new_dentry_path = get_dentry_path_str(new_dentry);
+    save_str_to_buf(p.event, old_dentry_path, 0);
+    save_str_to_buf(p.event, new_dentry_path, 1);
+    return events_perf_submit(&p, SECURITY_INODE_RENAME, 0);
 }
 
 SEC("kprobe/kallsyms_lookup_name")
@@ -6816,24 +6920,24 @@ int BPF_KPROBE(trace_ret_kallsyms_lookup_name)
     if (!should_trace(&p))
         return 0;
 
+
     args_t saved_args;
     if (load_args(&saved_args, KALLSYMS_LOOKUP_NAME) != 0)
         return 0;
     del_args(KALLSYMS_LOOKUP_NAME);
 
+    if (!should_submit(KALLSYMS_LOOKUP_NAME, &p))
+        return 0;
+
     char *name = (char *) saved_args.args[0];
     unsigned long address = PT_REGS_RC(ctx);
 
-    if (should_submit(KALLSYMS_LOOKUP_NAME, p.config)) {
-        save_str_to_buf(p.event, name, 0);
-        save_to_submit_buf(p.event, &address, sizeof(unsigned long), 1);
-        int id = get_task_syscall_id(p.event->task);
-        save_to_submit_buf(p.event, &id, sizeof(int), 2);
+    save_str_to_buf(p.event, name, 0);
+    save_to_submit_buf(p.event, &address, sizeof(unsigned long), 1);
+    int id = get_task_syscall_id(p.event->task);
+    save_to_submit_buf(p.event, &id, sizeof(int), 2);
 
-        events_perf_submit(&p, KALLSYMS_LOOKUP_NAME, 0);
-    }
-
-    return 0;
+    return events_perf_submit(&p, KALLSYMS_LOOKUP_NAME, 0);
 }
 
 SEC("kprobe/do_sigaction")
@@ -6844,6 +6948,9 @@ int BPF_KPROBE(trace_do_sigaction)
         return 0;
 
     if (!should_trace(&p))
+        return 0;
+
+    if (!should_submit(DO_SIGACTION, &p))
         return 0;
 
     // Initialize all relevant arguments values
@@ -7072,32 +7179,32 @@ static __always_inline void set_net_task_context(event_data_t *event, net_task_c
 }
 
 static __always_inline void should_submit_net_event(net_event_context_t *neteventctx,
-                                                    config_entry_t *config)
+                                                    program_data_t *p)
 {
     // configure network events that should be sent to userland
 
-    if (should_submit(NET_PACKET_CAP_BASE, config))
+    if (should_submit(NET_PACKET_CAP_BASE, p))
         neteventctx->md.submit |= CAP_NET_PACKET;
 
-    if (should_submit(NET_PACKET_IP, config))
+    if (should_submit(NET_PACKET_IP, p))
         neteventctx->md.submit |= SUB_NET_PACKET_IP;
 
-    if (should_submit(NET_PACKET_TCP, config))
+    if (should_submit(NET_PACKET_TCP, p))
         neteventctx->md.submit |= SUB_NET_PACKET_TCP;
 
-    if (should_submit(NET_PACKET_UDP, config))
+    if (should_submit(NET_PACKET_UDP, p))
         neteventctx->md.submit |= SUB_NET_PACKET_UDP;
 
-    if (should_submit(NET_PACKET_ICMP, config))
+    if (should_submit(NET_PACKET_ICMP, p))
         neteventctx->md.submit |= SUB_NET_PACKET_ICMP;
 
-    if (should_submit(NET_PACKET_ICMPV6, config))
+    if (should_submit(NET_PACKET_ICMPV6, p))
         neteventctx->md.submit |= SUB_NET_PACKET_ICMPV6;
 
-    if (should_submit(NET_PACKET_DNS, config))
+    if (should_submit(NET_PACKET_DNS, p))
         neteventctx->md.submit |= SUB_NET_PACKET_DNS;
 
-    if (should_submit(NET_PACKET_HTTP, config))
+    if (should_submit(NET_PACKET_HTTP, p))
         neteventctx->md.submit |= SUB_NET_PACKET_HTTP;
 }
 
@@ -7318,7 +7425,7 @@ int BPF_KPROBE(cgroup_bpf_run_filter_skb)
     neteventctx.bytes = 0; // no payload by default (changed inside skb prog)
 
     // mark network events to be submitted to userland
-    should_submit_net_event(&neteventctx, p.config);
+    should_submit_net_event(&neteventctx, &p);
 
     // (*) Use skb timestamp as the key for a map shared between this kprobe and
     // the skb ebpf program: this is **NOT SUPER** BUT, for older kernels, that

--- a/pkg/ebpf/events_pipeline.go
+++ b/pkg/ebpf/events_pipeline.go
@@ -264,12 +264,6 @@ func (t *Tracee) computeScopes(event *trace.Event) uint64 {
 			continue
 		}
 
-		// TODO: check if the event is traceable to some scope using a BPF map
-		if !filterScope.IsEventTraceable(eventID) {
-			utils.ClearBit(&matchedScopes, bitOffset)
-			continue
-		}
-
 		if !filterScope.ContextFilter.Filter(*event) {
 			utils.ClearBit(&matchedScopes, bitOffset)
 			continue
@@ -433,7 +427,7 @@ func (t *Tracee) sinkEvents(ctx context.Context, in <-chan *trace.Event) <-chan 
 		for event := range in {
 			// Only emit events requested by the user
 			id := events.ID(event.EventID)
-			if !t.events[id].emit {
+			if (t.events[id].emit & event.MatchedScopes) == 0 {
 				continue
 			}
 

--- a/pkg/ebpf/finding.go
+++ b/pkg/ebpf/finding.go
@@ -54,6 +54,7 @@ func newEvent(id int, name string, s trace.Event) *trace.Event {
 		ReturnValue:         s.ReturnValue,
 		StackAddresses:      s.StackAddresses,
 		ContextFlags:        s.ContextFlags,
+		MatchedScopes:       s.MatchedScopes,
 		Args:                s.Args,
 	}
 }

--- a/pkg/ebpf/rule_engine.go
+++ b/pkg/ebpf/rule_engine.go
@@ -32,7 +32,7 @@ func (t *Tracee) engineEvents(ctx context.Context, in <-chan *trace.Event) (<-ch
 				id := events.ID(event.EventID)
 
 				// if the event is marked as submit, we pass it to the engine
-				if t.events[id].submit {
+				if t.events[id].submit > 0 {
 					err := t.parseArguments(event)
 					if err != nil {
 						t.handleError(err)

--- a/pkg/ebpf/tracee.go
+++ b/pkg/ebpf/tracee.go
@@ -157,8 +157,8 @@ type fileExecInfo struct {
 }
 
 type eventConfig struct {
-	submit bool // event should be submitted to userspace
-	emit   bool // event should be emitted to the user
+	submit uint64 // event should be submitted to userspace (by scopes bitmap)
+	emit   uint64 // event should be emitted to the user (by scopes bitmap)
 }
 
 // Tracee traces system calls and system events using eBPF
@@ -212,8 +212,8 @@ func GetEssentialEventsList() map[events.ID]eventConfig {
 		events.SchedProcessExec: {},
 		events.SchedProcessExit: {},
 		events.SchedProcessFork: {},
-		events.CgroupMkdir:      {submit: true},
-		events.CgroupRmdir:      {submit: true},
+		events.CgroupMkdir:      {submit: 0xFFFFFFFFFFFFFFFF},
+		events.CgroupRmdir:      {submit: 0xFFFFFFFFFFFFFFFF},
 	}
 }
 
@@ -243,16 +243,16 @@ func GetCaptureEventsList(cfg Config) map[events.ID]eventConfig {
 	return captureEvents
 }
 
-func (t *Tracee) handleEventsDependencies(eventId events.ID) {
+func (t *Tracee) handleEventsDependencies(eventId events.ID, submitMap uint64) {
 	definition := events.Definitions.Get(eventId)
 	eDependencies := definition.Dependencies
 	for _, dependentEvent := range eDependencies.Events {
 		ec, ok := t.events[dependentEvent.EventID]
 		if !ok {
 			ec = eventConfig{}
-			t.handleEventsDependencies(dependentEvent.EventID)
+			t.handleEventsDependencies(dependentEvent.EventID, submitMap)
 		}
-		ec.submit = true
+		ec.submit = submitMap
 		t.events[dependentEvent.EventID] = ec
 	}
 }
@@ -288,13 +288,20 @@ func New(cfg Config) (*Tracee, error) {
 	// Events chosen by the user
 	for filterScope := range t.config.FilterScopes.Map() {
 		for e := range filterScope.EventsToTrace {
-			t.events[e] = eventConfig{submit: true, emit: true}
+			var submit, emit uint64
+			if _, ok := t.events[e]; ok {
+				submit = t.events[e].submit
+				emit = t.events[e].emit
+			}
+			utils.SetBit(&submit, uint(filterScope.ID))
+			utils.SetBit(&emit, uint(filterScope.ID))
+			t.events[e] = eventConfig{submit: submit, emit: emit}
 		}
 	}
 
 	// Handles all essential events dependencies
-	for id := range t.events {
-		t.handleEventsDependencies(id)
+	for id, evt := range t.events {
+		t.handleEventsDependencies(id, evt.submit)
 	}
 
 	// Add Required (by enabled events) capabilities to its ring
@@ -598,31 +605,31 @@ func (t *Tracee) initDerivationTable() error {
 	t.eventDerivations = derive.Table{
 		events.CgroupMkdir: {
 			events.ContainerCreate: {
-				Enabled:        t.events[events.ContainerCreate].submit,
+				Enabled:        t.events[events.ContainerCreate].submit > 0,
 				DeriveFunction: derive.ContainerCreate(t.containers),
 			},
 		},
 		events.CgroupRmdir: {
 			events.ContainerRemove: {
-				Enabled:        t.events[events.ContainerRemove].submit,
+				Enabled:        t.events[events.ContainerRemove].submit > 0,
 				DeriveFunction: derive.ContainerRemove(t.containers),
 			},
 		},
 		events.PrintSyscallTable: {
 			events.HookedSyscalls: {
-				Enabled:        t.events[events.PrintSyscallTable].submit,
+				Enabled:        t.events[events.PrintSyscallTable].submit > 0,
 				DeriveFunction: derive.DetectHookedSyscall(t.kernelSymbols),
 			},
 		},
 		events.PrintNetSeqOps: {
 			events.HookedSeqOps: {
-				Enabled:        t.events[events.HookedSeqOps].submit,
+				Enabled:        t.events[events.HookedSeqOps].submit > 0,
 				DeriveFunction: derive.HookedSeqOps(t.kernelSymbols),
 			},
 		},
 		events.SharedObjectLoaded: {
 			events.SymbolsLoaded: {
-				Enabled: t.events[events.SymbolsLoaded].submit,
+				Enabled: t.events[events.SymbolsLoaded].submit > 0,
 				DeriveFunction: derive.SymbolsLoaded(
 					soLoader,
 					watchedSymbols,
@@ -635,63 +642,63 @@ func (t *Tracee) initDerivationTable() error {
 		//
 		events.NetPacketIPBase: {
 			events.NetPacketIPv4: {
-				Enabled:        t.events[events.NetPacketIPv4].submit,
+				Enabled:        t.events[events.NetPacketIPv4].submit > 0,
 				DeriveFunction: derive.NetPacketIPv4(),
 			},
 			events.NetPacketIPv6: {
-				Enabled:        t.events[events.NetPacketIPv6].submit,
+				Enabled:        t.events[events.NetPacketIPv6].submit > 0,
 				DeriveFunction: derive.NetPacketIPv6(),
 			},
 		},
 		events.NetPacketTCPBase: {
 			events.NetPacketTCP: {
-				Enabled:        t.events[events.NetPacketTCP].submit,
+				Enabled:        t.events[events.NetPacketTCP].submit > 0,
 				DeriveFunction: derive.NetPacketTCP(),
 			},
 		},
 		events.NetPacketUDPBase: {
 			events.NetPacketUDP: {
-				Enabled:        t.events[events.NetPacketUDP].submit,
+				Enabled:        t.events[events.NetPacketUDP].submit > 0,
 				DeriveFunction: derive.NetPacketUDP(),
 			},
 		},
 		events.NetPacketICMPBase: {
 			events.NetPacketICMP: {
-				Enabled:        t.events[events.NetPacketICMP].submit,
+				Enabled:        t.events[events.NetPacketICMP].submit > 0,
 				DeriveFunction: derive.NetPacketICMP(),
 			},
 		},
 		events.NetPacketICMPv6Base: {
 			events.NetPacketICMPv6: {
-				Enabled:        t.events[events.NetPacketICMPv6].submit,
+				Enabled:        t.events[events.NetPacketICMPv6].submit > 0,
 				DeriveFunction: derive.NetPacketICMPv6(),
 			},
 		},
 		events.NetPacketDNSBase: {
 			events.NetPacketDNS: {
-				Enabled:        t.events[events.NetPacketDNS].submit,
+				Enabled:        t.events[events.NetPacketDNS].submit > 0,
 				DeriveFunction: derive.NetPacketDNS(),
 			},
 			events.NetPacketDNSRequest: {
-				Enabled:        t.events[events.NetPacketDNSRequest].submit,
+				Enabled:        t.events[events.NetPacketDNSRequest].submit > 0,
 				DeriveFunction: derive.NetPacketDNSRequest(),
 			},
 			events.NetPacketDNSResponse: {
-				Enabled:        t.events[events.NetPacketDNSResponse].submit,
+				Enabled:        t.events[events.NetPacketDNSResponse].submit > 0,
 				DeriveFunction: derive.NetPacketDNSResponse(),
 			},
 		},
 		events.NetPacketHTTPBase: {
 			events.NetPacketHTTP: {
-				Enabled:        t.events[events.NetPacketHTTP].submit,
+				Enabled:        t.events[events.NetPacketHTTP].submit > 0,
 				DeriveFunction: derive.NetPacketHTTP(),
 			},
 			events.NetPacketHTTPRequest: {
-				Enabled:        t.events[events.NetPacketHTTPRequest].submit,
+				Enabled:        t.events[events.NetPacketHTTPRequest].submit > 0,
 				DeriveFunction: derive.NetPacketHTTPRequest(),
 			},
 			events.NetPacketHTTPResponse: {
-				Enabled:        t.events[events.NetPacketHTTPResponse].submit,
+				Enabled:        t.events[events.NetPacketHTTPResponse].submit > 0,
 				DeriveFunction: derive.NetPacketHTTPResponse(),
 			},
 		},
@@ -743,7 +750,7 @@ func (t *Tracee) getOptionsConfig() uint32 {
 
 func (t *Tracee) computeConfigValues() []byte {
 	// config_entry
-	configVal := make([]byte, 384)
+	configVal := make([]byte, 256)
 
 	// tracee_pid
 	binary.LittleEndian.PutUint32(configVal[0:4], uint32(os.Getpid()))
@@ -877,20 +884,6 @@ func (t *Tracee) computeConfigValues() []byte {
 	// pid_min
 	binary.LittleEndian.PutUint64(configVal[248:256], t.config.FilterScopes.PIDFilterMin())
 
-	// Next 128 bytes (1024 bits) are used for events_to_submit configuration
-	// Set according to events chosen by the user
-	for id, e := range t.events {
-		if id >= 1024 {
-			// we support up to 1024 events shared with bpf code
-			continue
-		}
-		if e.submit {
-			index := id / 8
-			offset := id % 8
-			configVal[256+index] |= 1 << offset
-		}
-	}
-
 	return configVal
 }
 
@@ -945,6 +938,19 @@ func (t *Tracee) validateKallsymsDependencies() {
 }
 
 func (t *Tracee) populateBPFMaps() error {
+	// Prepare events map
+	eventsMap, err := t.bpfModule.GetMap("events_map")
+	if err != nil {
+		return err
+	}
+	for id, ecfg := range t.events {
+		submit := ecfg.submit
+		err := eventsMap.Update(unsafe.Pointer(&id), unsafe.Pointer(&submit))
+		if err != nil {
+			return err
+		}
+	}
+
 	// Prepare 32bit to 64bit syscall number mapping
 	sys32to64BPFMap, err := t.bpfModule.GetMap("sys_32_to_64_map") // u32, u32
 	if err != nil {
@@ -1140,7 +1146,7 @@ func getTailCalls(eventConfigs map[events.ID]eventConfig) ([]events.TailCall, er
 			tailCallProgs[tailCallStr] = true
 		}
 		// validate the event and add to the syscall tail calls
-		if def.Syscall && cfg.submit && e < events.MaxSyscallID {
+		if def.Syscall && cfg.submit > 0 && e < events.MaxSyscallID {
 			enterInitTailCall.AddIndex(uint32(e))
 			enterSubmitTailCall.AddIndex(uint32(e))
 			exitInitTailCall.AddIndex(uint32(e))
@@ -1475,7 +1481,7 @@ func (t *Tracee) updateFileSHA() {
 }
 
 func (t *Tracee) invokeInitEvents() {
-	if t.events[events.InitNamespaces].emit {
+	if t.events[events.InitNamespaces].emit > 0 {
 		capabilities.GetInstance().Requested(func() error { // ring2
 			systemInfoEvent := events.InitNamespacesEvent()
 			t.config.ChanEvents <- systemInfoEvent
@@ -1483,7 +1489,7 @@ func (t *Tracee) invokeInitEvents() {
 		}, cap.SYS_PTRACE)
 		t.stats.EventCount.Increment()
 	}
-	if t.events[events.ExistingContainer].emit {
+	if t.events[events.ExistingContainer].emit > 0 {
 		for _, e := range events.ExistingContainersEvents(t.containers, t.config.ContainersEnrich) {
 			t.config.ChanEvents <- e
 			t.stats.EventCount.Increment()

--- a/pkg/ebpf/tracee_test.go
+++ b/pkg/ebpf/tracee_test.go
@@ -135,11 +135,11 @@ func Test_getTailCalls(t *testing.T) {
 		{
 			name: "happy path - some direct syscalls and syscall requiring events",
 			events: map[events.ID]eventConfig{
-				events.Ptrace:           {submit: true, emit: true},
-				events.ClockSettime:     {submit: true, emit: true},
-				events.SecurityFileOpen: {submit: true, emit: true},
-				events.MemProtAlert:     {submit: true, emit: true},
-				events.SocketDup:        {submit: true, emit: true},
+				events.Ptrace:           {submit: 1, emit: true},
+				events.ClockSettime:     {submit: 1, emit: true},
+				events.SecurityFileOpen: {submit: 1, emit: true},
+				events.MemProtAlert:     {submit: 1, emit: true},
+				events.SocketDup:        {submit: 1, emit: true},
 			},
 			expectedTailCalls: []events.TailCall{
 				{MapName: "sys_exit_tails", MapIndexes: []uint32{uint32(events.Dup), uint32(events.Dup2), uint32(events.Dup3)}, ProgName: "sys_dup_exit_tail"},


### PR DESCRIPTION
When using multiple scopes, probes may be attached due to a single scope
but it's events not being requiered at all by other scopes.
As such, checking if the event is required by any of the matched scopes
should be done as part of checking an event submit.

As part of this patch, should_submit checks were added in most kprobe
programs.
They were previously unnecessary because they would only be attached as
part of the single scope provided. With the addition of multiple scopes
it is not guarenteed that probe attaching is equivalent to a submit
check (if there is a one to one relation between probe and event).